### PR TITLE
prevent creation of groups with duplicate names

### DIFF
--- a/apps/backend/src/models/group.js
+++ b/apps/backend/src/models/group.js
@@ -1,5 +1,4 @@
 const mongoose = require("mongoose");
-const user = require("./user");
 
 const groupSchema = new mongoose.Schema(
   {
@@ -8,6 +7,7 @@ const groupSchema = new mongoose.Schema(
       required: true,
       minLength: 4,
       maxLength: 20,
+      unique:true
     },
     description: {
       type: String,

--- a/apps/backend/src/routes/groups.js
+++ b/apps/backend/src/routes/groups.js
@@ -21,6 +21,10 @@ groupRouter.post("/group/create", userAuth, async (req, res) => {
     }
     // const loggedUser = req.user;
     // const adminName = loggedUser.firstName;
+    const groupExists=await  Group.find({groupName:groupName})
+    if(groupExists.length>0){
+      return res.status(400).json({message:"Group with this name already exists. Please choose a different name"})
+    }
     const group = new Group({
       groupName,
       description,


### PR DESCRIPTION
Description:
This PR adds a validation check to ensure that group names are unique.
If a group with the same name already exists, the API now returns a 400 error with an appropriate message.

Changes made:

Updated apps/backend/src/model/group.js to enforce a unique index on groupName.

Updated apps/backend/src/routes/groups.js (and controller logic) to handle duplicate name validation before creating a new group.

Why:
Previously, users could create multiple groups with the same name, which caused confusion and potential conflicts.
This fix ensures each group name remains unique across the system.

How to Test:

Try creating a group with a unique name → ✅ should succeed.

Try creating another group with the same name → ❌ should return 400: Group name already exists.

Labels:

good first issue, hacktoberfest, enhancement ,  hacktoberfest2025 , hacktoberfest-accepted